### PR TITLE
Added typing to the code base

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,13 +9,28 @@ import { Distribution, AllowedMethods, ViewerProtocolPolicy } from 'aws-cdk-lib/
 import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { PolicyStatement, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
-interface StaticSiteProps {
+
+/**
+ * @typedef IStaticSiteProps
+ * @property {string}         domainName   - domain name to depoy for
+ * @property {string}         webAssetPath -  Path to your web asset build folder [e.g. .dist || .build || .out]
+ */
+interface IStaticSiteProps {
     readonly domainName: string;
     readonly webAssetPath: string;
 }
 
+/**
+ * @class
+ */
 class HostedSite extends Construct {
-    constructor(scope: Construct, id: string, props: StaticSiteProps) {
+    /**
+     * 
+     * @param {Construct} scope 
+     * @param {string} id 
+     * @param {IStaticSiteProps} props 
+     */
+    constructor(scope: Construct, id: string, props: IStaticSiteProps) {
         super(scope, id);
 
         const bucket = new Bucket(this, 'Bucket', {
@@ -44,9 +59,9 @@ class HostedSite extends Construct {
 
         const distribution = new Distribution(this, 'Distribution', {
             defaultBehavior: {
-            origin: new S3Origin(bucket),
-            allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
-            viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS
+                origin: new S3Origin(bucket),
+                allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+                viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS
             },
             enabled: true,
             domainNames: [props.domainName],
@@ -61,7 +76,7 @@ class HostedSite extends Construct {
             resources: [bucket.arnForObjects('*')],
             principals: [new ServicePrincipal('cloudfront.amazonaws.com')],
             conditions: {
-            StringEquals: {'aws:Referer': certificate.certificateArn}
+                StringEquals: { 'aws:Referer': certificate.certificateArn }
             },
         }));
 
@@ -82,18 +97,22 @@ class HostedSite extends Construct {
         new CfnOutput(this, 'BucketUrl', {
             value: bucket.bucketWebsiteUrl,
         });
-
-
     }
 }
 
-interface StaticSiteStackProps extends StackProps {
+/**
+ * @typedef IStaticSiteStackProps
+ * @property {string}         domainName   - domain name to depoy for
+ * @property {string}         webAssetPath -  Path to your web asset build folder [e.g. .dist || .build || .out]
+ * @extends StackProps
+ */
+interface IStaticSiteStackProps extends StackProps {
     readonly domainName: string;
     readonly webAssetPath: string;
 }
 
 export class StaticSiteStack extends Stack {
-    constructor(scope: Construct, id: string, props: StaticSiteStackProps) {
+    constructor(scope: Construct, id: string, props: IStaticSiteStackProps) {
         super(scope, id, props);
 
         new HostedSite(this, 'Blip', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,38 @@
 import { App } from 'aws-cdk-lib';
+import { type CloudFormationStackArtifact } from 'aws-cdk-lib/cx-api';
 import { StaticSiteStack } from './app';
 
-interface ApplicationProps {
+/**
+ * @typedef environment
+ * @property {string} account - AWS account ID
+ * @property {string} region  - AWS deploy region 
+ */
+type environment = { account: string, region: string }
+
+/**
+* @typedef IApplicationProps
+* @property {string}         domainName   - domain name to depoy for
+* @property {string}         webAssetPath -  Path to your web asset build folder [e.g. .dist || .build || .out]
+* @property {environment}    env          - Object containing your AWS #account ID and #region
+* @exports IApplicationProps
+*/
+interface IApplicationProps {
     readonly domainName: string;
     readonly webAssetPath: string;
-    readonly env: { account: string, region: string };
+    readonly env: environment;
 }
+
+/**
+ * @class
+ * @exports Application
+ */
 export class Application {
-    constructor(props: ApplicationProps) {
+    /**
+     * @constructor
+     * @param {IApplicationProps} props 
+     * @returns {CloudFormationStackArtifact} temlate
+     */
+    constructor(props: IApplicationProps) {
 
         const app = new App();
         const stack = new StaticSiteStack(app, 'StaticSiteStack', {
@@ -20,7 +45,7 @@ export class Application {
         });
 
         const synth = app.synth();
-        const template = synth.getStackByName(stack.stackName).template;
+        const template: CloudFormationStackArtifact = synth.getStackByName(stack.stackName).template;
 
         return template;
 


### PR DESCRIPTION
closes #11

Added basic typing for interfaces, classes and constructors; note type annotation for CloudFormationStackArtifact as a return is a little cumbersome. We can remove it if we don't care about being super strictly typed.